### PR TITLE
Update cinderblock.xml

### DIFF
--- a/cinderblock.xml
+++ b/cinderblock.xml
@@ -21,6 +21,6 @@
 	<source>lib/imgui/imgui.cpp</source>
 	<source>lib/imgui/imgui_draw.cpp</source>
 	<source>lib/imgui/imgui_demo.cpp</source>
-	
+	<source>lib/imgui/imgui_widgets.cpp</source>
 </block>
 </cinder>


### PR DESCRIPTION
imgui_widgets.cpp was left out. Projects made with Tinderbox will now build with the cinderblock.